### PR TITLE
Fix service auto-start command handling

### DIFF
--- a/NIGIL_status.py
+++ b/NIGIL_status.py
@@ -1115,8 +1115,16 @@ def main(argv: Optional[List[str]] = None):
                         help="Ветка GitHub для self-update")
     parser.add_argument("--update-files", nargs="*",
                         help="Список файлов (относительно корня репозитория) для self-update")
+    parser.add_argument("command", nargs="?", help="Необязательная команда (run или self-update)")
 
     args = parser.parse_args(argv)
+
+    command_raw = getattr(args, "command", None)
+    command = (command_raw or "run").strip().lower().replace("-", "_")
+    if command == "self_update":
+        setattr(args, "self_update", True)
+    elif command not in {"run"}:
+        parser.error(f"Неизвестная команда: {command_raw!r}")
 
     if getattr(args, "self_update", False):
         files = args.update_files or None

--- a/install.sh
+++ b/install.sh
@@ -386,7 +386,7 @@ UNIT_ENVIRONMENT+="$(build_env_line "NIGIL_PIN_STATUS_MESSAGE" "$PIN_STATUS")"
 UNIT_ENVIRONMENT+="$(build_env_line "NIGIL_LIVE_POST_ONLY" "$LIVE_POST")"
 UNIT_ENVIRONMENT+="$(build_env_line "NIGIL_COMMAND_REPLY_TTL" "$COMMAND_TTL")"
 
-EXEC_START_LINE="$(build_execstart_line "$PYTHON_BIN" "$SCRIPT_DIR/NIGIL_status.py" run)"
+EXEC_START_LINE="$(build_execstart_line "$PYTHON_BIN" "$SCRIPT_DIR/NIGIL_status.py")"
 
 UNIT_CONTENT="[Unit]
 Description=${PROJECT_NAME}
@@ -428,6 +428,6 @@ cat <<MSG
   export NIGIL_PIN_STATUS_MESSAGE='${PIN_STATUS}'
   export NIGIL_LIVE_POST_ONLY='${LIVE_POST}'
   export NIGIL_COMMAND_REPLY_TTL='${COMMAND_TTL}'
-  ${PYTHON_BIN} ${SCRIPT_DIR}/NIGIL_status.py run
+  ${PYTHON_BIN} ${SCRIPT_DIR}/NIGIL_status.py
 
 MSG


### PR DESCRIPTION
## Summary
- allow running the bot even when an extra `run` command is provided and treat `self-update` as an alias for backward compatibility
- update the generated systemd unit and manual run instructions to call the script without the obsolete positional argument

## Testing
- python3 NIGIL_status.py --help
- python3 NIGIL_status.py run

------
https://chatgpt.com/codex/tasks/task_e_68e15562c5708320ae3cbb3f7d69cd9d